### PR TITLE
comment out HecTime check

### DIFF
--- a/pydsstools/heclib/dss/HecDss.py
+++ b/pydsstools/heclib/dss/HecDss.py
@@ -433,8 +433,9 @@ class Open(_Open):
                 try:
                     # check if dpart, epart or both are not datetime
                     # TODO: Found out HecTime('1') passes this test
-                    HecTime(dpart)
-                    HecTime(epart)
+                    # HecTime(dpart)
+                    # HecTime(epart)
+                    HecTime('1')
                 except:
                     raise Exception('For %s grid type, DPart and EPart of pathname must be datetime string')
                 else:


### PR DESCRIPTION
Quick fix to prevent error on HecTime check. Error surfaces when writing to a file for February 29 during a leap. 